### PR TITLE
Fix dashboard access and login redirect flow

### DIFF
--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -125,8 +125,16 @@ export default function AdminDashboard() {
   });
   const [showNewProjectDialog, setShowNewProjectDialog] = useState(false);
 
-  if (!isAuthenticated || user?.type !== "admin") {
-    return <Navigate to="/" replace />;
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate to="/login" replace state={{ from: location.pathname }} />
+    );
+  }
+  if (user?.type !== "admin") {
+    const fallback = user?.type === "farmer" ? "/farmer-dashboard" : "/";
+    return <Navigate to={fallback} replace />;
   }
 
   const handleFarmerStatusUpdate = (farmerId: string, newStatus: string) => {

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -128,9 +128,7 @@ export default function AdminDashboard() {
   const location = useLocation();
 
   if (!isAuthenticated) {
-    return (
-      <Navigate to="/login" replace state={{ from: location.pathname }} />
-    );
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
   if (user?.type !== "admin") {
     const fallback = user?.type === "farmer" ? "/farmer-dashboard" : "/";

--- a/client/pages/FarmerDashboard.tsx
+++ b/client/pages/FarmerDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/client/pages/FarmerDashboard.tsx
+++ b/client/pages/FarmerDashboard.tsx
@@ -84,8 +84,16 @@ export default function FarmerDashboard() {
     }
   }, [user]);
 
-  if (!isAuthenticated || user?.type !== "farmer") {
-    return <Navigate to="/" replace />;
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate to="/login" replace state={{ from: location.pathname }} />
+    );
+  }
+  if (user?.type !== "farmer") {
+    const fallback = user?.type === "admin" ? "/admin-dashboard" : "/";
+    return <Navigate to={fallback} replace />;
   }
 
   const handleProfileUpdate = async (e: React.FormEvent) => {

--- a/client/pages/FarmerDashboard.tsx
+++ b/client/pages/FarmerDashboard.tsx
@@ -87,9 +87,7 @@ export default function FarmerDashboard() {
   const location = useLocation();
 
   if (!isAuthenticated) {
-    return (
-      <Navigate to="/login" replace state={{ from: location.pathname }} />
-    );
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
   if (user?.type !== "farmer") {
     const fallback = user?.type === "admin" ? "/admin-dashboard" : "/";

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -11,7 +11,8 @@ export default function Login() {
 
   // If already authenticated, send user to their dashboard
   if (isAuthenticated) {
-    const path = user?.type === "admin" ? "/admin-dashboard" : "/farmer-dashboard";
+    const path =
+      user?.type === "admin" ? "/admin-dashboard" : "/farmer-dashboard";
     return <Navigate to={path} replace />;
   }
 

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -1,18 +1,27 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Navigate } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
 import AuthModal from "@/components/AuthModal";
 
 export default function Login() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isAuthenticated, user } = useAuth();
   const [open, setOpen] = useState(true);
 
+  // If already authenticated, send user to their dashboard
+  if (isAuthenticated) {
+    const path = user?.type === "admin" ? "/admin-dashboard" : "/farmer-dashboard";
+    return <Navigate to={path} replace />;
+  }
+
   useEffect(() => {
-    if (!open) {
+    // Only navigate back if modal closed WITHOUT logging in
+    if (!open && !isAuthenticated) {
       const from = (location.state as any)?.from || "/";
       navigate(from, { replace: true });
     }
-  }, [open, navigate, location.state]);
+  }, [open, isAuthenticated, navigate, location.state]);
 
   return (
     <div className="min-h-[60vh]">


### PR DESCRIPTION
## Purpose
Fix dashboard accessibility issues where admin and farmer dashboards were not accessible, and implement proper redirect flow so users are directed to their appropriate dashboard after login instead of the homepage.

## Code changes
- **AdminDashboard.tsx**: Added proper authentication checks with redirect to login page for unauthenticated users, and role-based fallback redirects for non-admin users
- **FarmerDashboard.tsx**: Added similar authentication checks with redirect to login page for unauthenticated users, and role-based fallback redirects for non-farmer users  
- **Login.tsx**: Added logic to automatically redirect already authenticated users to their appropriate dashboard (admin or farmer) and improved modal close handling to only navigate back when user closes modal without logging in

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b185bfb4b63b4600a6a7cf407904f2a7/flare-realm)

👀 [Preview Link](https://b185bfb4b63b4600a6a7cf407904f2a7-flare-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b185bfb4b63b4600a6a7cf407904f2a7</projectId>-->
<!--<branchName>flare-realm</branchName>-->